### PR TITLE
Fixed potential deadlock/infinite loop when isNecessary returns false

### DIFF
--- a/07-concurrency_channels/03-channels/example3/example3.go
+++ b/07-concurrency_channels/03-channels/example3/example3.go
@@ -50,7 +50,7 @@ func performInserts() {
 	}
 
 	// Process the insert results as they complete.
-	for {
+	for waitResponses > 0 {
 		// Wait for a response from a goroutine.
 		err := <-ch
 
@@ -63,9 +63,6 @@ func performInserts() {
 
 		// Decrement the wait count and determine if we are done.
 		waitResponses--
-		if waitResponses == 0 {
-			break
-		}
 	}
 
 	log.Println("Inserts Complete")


### PR DESCRIPTION
If `isNecessary` returns `false` for all calls (which is reasonable), then `err := <-ch` (on [line 55](https://github.com/ArdanStudios/gotraining/blob/54e72136eaac33aacc6dcd18cb7d79f305c56556/07-concurrency_channels/03-channels/example3/example3.go#L55)) will cause something like:
```shellsession
$ ./example3
2015/05/28 18:06:02 Inserts Started
fatal error: all goroutines are asleep - deadlock!

goroutine 1 [chan receive]:
main.performInserts()
    ~/ardan-studios-gotraining/gotraining/07-concurrency_channels/03-channels/example3/example3.go:55 +0x230
main.main()
    ~/ardan-studios-gotraining/gotraining/07-concurrency_channels/03-channels/example3/example3.go:28 +0x1b
```

A solution is to remove the `if/break` construct (starting on [line 66](https://github.com/ArdanStudios/gotraining/blob/54e72136eaac33aacc6dcd18cb7d79f305c56556/07-concurrency_channels/03-channels/example3/example3.go#L66)) and add in a conditional that checks `waitResponses` as part of the entry into the for loop.

After this, even if `isNecessary` always returns `false`, we end up with output resembling:
```shellsession
$ ./example3
2015/05/28 18:17:26 Inserts Started
2015/05/28 18:17:26 Inserts Complete
```