### PR TITLE
Unecessary conversion from byte slice to string

### DIFF
--- a/10-standard_library/02-encoding/example3/example3.go
+++ b/10-standard_library/02-encoding/example3/example3.go
@@ -63,7 +63,7 @@ func main() {
 	}
 
 	// Convert the byte slice to a string and display.
-	fmt.Printf("%s\n\n", string(r1))
+	fmt.Printf("%s\n\n", r1)
 
 	// Marshal the buoyStation value into a pretty-print
 	// JSON string representation.


### PR DESCRIPTION
We do not need to make a conversion to String when using fmt.Printf("%s") because it %s supports byte slice and/or strings.