### PR TITLE
Wrong link for Custom Marshaler and Unmarshler

### DIFF
--- a/10-standard_library/02-encoding/readme.md
+++ b/10-standard_library/02-encoding/readme.md
@@ -19,7 +19,7 @@ http://www.goinggo.net/2014/01/decode-json-documents-in-go.html
 
 [Marshal a user defined type](example3/example3.go) ([Go Playground](http://play.golang.org/p/rLDpqYbnGR))
 
-[Custom Marshaler and Unmarshler](example3/example3.go) ([Go Playground](http://play.golang.org/p/TOYrZJoLei))
+[Custom Marshaler and Unmarshler](example4/example4.go) ([Go Playground](http://play.golang.org/p/TOYrZJoLei))
 
 ## Exercises
 


### PR DESCRIPTION
I believe the link for "Custom Marshaler and Unmarshler" should be:
https://github.com/ArdanStudios/gotraining/blob/master/10-standard_library/02-encoding/example4/example4.go