### PR TITLE
Add middleware support

### DIFF
--- a/13-http/api/app/context.go
+++ b/13-http/api/app/context.go
@@ -35,6 +35,7 @@ type Context struct {
 	Request   *http.Request
 	Params    map[string]string
 	SessionID string
+	Status    int
 }
 
 // Error handles all error responses for the API.
@@ -55,6 +56,8 @@ func (c *Context) Error(err error) {
 // If code is StatusNoContent, v is expected to be nil.
 func (c *Context) Respond(data interface{}, code int) {
 	log.Printf("%v : api : Respond [%d] : Started", c.SessionID, code)
+
+	c.Status = code
 
 	if code == http.StatusNoContent {
 		c.WriteHeader(http.StatusNoContent)

--- a/13-http/api/middleware/request_logger.go
+++ b/13-http/api/middleware/request_logger.go
@@ -1,0 +1,29 @@
+package middleware
+
+import (
+	"log"
+	"time"
+
+	"github.com/ArdanStudios/gotraining/13-http/api/app"
+)
+
+// RequestLogger writes some information about the request to the logs in
+// the format: SESSIONID : (200) GET /foo -> IP ADDR (latency)
+func RequestLogger(h app.Handler) app.Handler {
+	return func(c *app.Context) error {
+		log.Printf("%v : middleware : RequestLogger : Started", c.SessionID)
+
+		start := time.Now()
+		err := h(c)
+
+		log.Printf("%v : (%d) %s %s -> %s (%s)",
+			c.SessionID,
+			c.Status, c.Request.Method, c.Request.URL.Path,
+			c.Request.RemoteAddr, time.Since(start),
+		)
+
+		log.Printf("%v : middleware : RequestLogger : Completed", c.SessionID)
+
+		return err
+	}
+}


### PR DESCRIPTION
Adding just one type and one method to the public API gets some basic middleware support. This would probably get placed in a middleware package with each middleware getting its own file. 

Depending where the middleware chooses to call the provided `app.Handler` you get a before, around, or after middleware. The middleware also has the option of canceling the execution chain (think authorization) meaning that the handler for the given route only needs to concern itself with the happy path.

What this doesn't provide is a way to apply some set of middleware only to a subset of routes, but even so, I think it's a good example of an approach. 

A basic middleware would look something like:

```go
// middleware/yo.go
package middleware

import (
	"fmt"

	"github.com/ArdanStudios/gotraining/13-http/api/app"
)

func Yo(h app.Handler) app.Handler {
	return func(c *app.Context) error {
		fmt.Println("Before Yo")
		err := h(c)
		fmt.Println("After yo")
		return err
	}
}
```

Do you think this is something that should be included in the example as something that could be put into production?